### PR TITLE
No us/fix test suites

### DIFF
--- a/src/controllers/tests/user.controller.spec.ts
+++ b/src/controllers/tests/user.controller.spec.ts
@@ -21,6 +21,7 @@ describe('UserController', () => {
   let userController: UserController;
   let userService: UserService;
   let statisticsService: StatisticsService;
+  let prisma: PrismaService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -53,6 +54,7 @@ describe('UserController', () => {
     userController = module.get<UserController>(UserController);
     userService = module.get<UserService>(UserService);
     statisticsService = module.get<StatisticsService>(StatisticsService);
+    prisma = module.get<PrismaService>(PrismaService);
   });
 
   it('should be defined', () => {
@@ -104,6 +106,7 @@ describe('UserController', () => {
 
   describe('getUserStatistics', () => {
     it('should return user statistics', async () => {
+      jest.spyOn(prisma.user, 'findUnique').mockResolvedValue(mockTestUser);
       const mockTestUserStatistics = {
         graph: {
           Criatividade: 2,
@@ -146,7 +149,7 @@ describe('UserController', () => {
         expect(error).toBeInstanceOf(HttpException);
         if (error instanceof HttpException) {
           expect(error.getStatus()).toBe(HttpStatus.NOT_FOUND);
-          expect(error.getResponse()).toEqual('User not found');
+          expect(error.getResponse()).toEqual('User not found.');
         }
       }
     });

--- a/src/controllers/tests/user.controller.spec.ts
+++ b/src/controllers/tests/user.controller.spec.ts
@@ -121,6 +121,10 @@ describe('UserController', () => {
       } as StatisticsResponseDTO;
 
       jest
+        .spyOn(userService, 'updateUserStreak')
+        .mockImplementation(() => Promise.resolve());
+
+      jest
         .spyOn(statisticsService, 'getUserStatistics')
         .mockResolvedValue(mockTestUserStatistics);
 

--- a/src/controllers/tests/user.controller.spec.ts
+++ b/src/controllers/tests/user.controller.spec.ts
@@ -136,16 +136,20 @@ describe('UserController', () => {
       expect(result).toEqual(mockTestUserStatistics);
     });
 
-    it('should propagate error from service if user not found', async () => {
+    it('should propagate error from service if user not found.', async () => {
       jest
         .spyOn(statisticsService, 'getUserStatistics')
         .mockRejectedValue(
-          new HttpException('User not found', HttpStatus.NOT_FOUND),
+          new HttpException('User not found.', HttpStatus.NOT_FOUND),
         );
 
       const mockRequest = {
         payload: { userId: 'invalid' },
       } as AuthenticatedRequest;
+
+      jest
+        .spyOn(userService, 'updateUserStreak')
+        .mockImplementation(() => Promise.resolve());
 
       try {
         await userController.getUserStatistics(mockRequest);
@@ -226,11 +230,11 @@ describe('UserController', () => {
       });
     });
 
-    it('should throw error if user not found', async () => {
+    it('should throw error if user not found.', async () => {
       jest
         .spyOn(userService, 'getUserProfile')
         .mockRejectedValue(
-          new HttpException('User not found', HttpStatus.NOT_FOUND),
+          new HttpException('User not found.', HttpStatus.NOT_FOUND),
         );
 
       const mockReq = {
@@ -238,7 +242,7 @@ describe('UserController', () => {
       } as AuthenticatedRequest;
 
       await expect(userController.getUserProfile(mockReq)).rejects.toThrow(
-        new HttpException('User not found', HttpStatus.NOT_FOUND),
+        new HttpException('User not found.', HttpStatus.NOT_FOUND),
       );
     });
   });

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -70,7 +70,7 @@ export class AuthService {
     });
 
     if (!user) {
-      throw new HttpException('User not found', HttpStatus.NOT_FOUND);
+      throw new HttpException('User not found.', HttpStatus.NOT_FOUND);
     }
 
     const interests = user.user_interest

--- a/src/services/statistics.service.ts
+++ b/src/services/statistics.service.ts
@@ -11,7 +11,7 @@ export class StatisticsService {
     });
 
     if (!user) {
-      throw new HttpException('User not found', HttpStatus.NOT_FOUND);
+      throw new HttpException('User not found.', HttpStatus.NOT_FOUND);
     }
 
     const now = new Date();

--- a/src/services/tests/post.service.spec.ts
+++ b/src/services/tests/post.service.spec.ts
@@ -16,7 +16,6 @@ jest.mock('@aws-sdk/client-s3');
 describe('PostService', () => {
   let service: PostService;
   let prisma: PrismaService;
-  let presignedService: PresignedService;
   const page = 1;
   const postsPerPage = 10;
 
@@ -41,7 +40,6 @@ describe('PostService', () => {
 
     service = module.get<PostService>(PostService);
     prisma = module.get<PrismaService>(PrismaService);
-    presignedService = module.get<PresignedService>(PresignedService);
   });
 
   it('should be defined', () => {
@@ -65,9 +63,6 @@ describe('PostService', () => {
       .spyOn(prisma.post, 'findMany')
       .mockResolvedValue([mockTestPost, mockTestPostSaved]);
     jest.spyOn(prisma.user, 'findUnique').mockResolvedValue(mockTestUser);
-    jest
-      .spyOn(presignedService, 'getDownloadURL')
-      .mockResolvedValue('https://example.com/presigned-url');
 
     const result = await service.getPostsWithSavedStatusPaginated(
       '2140b95c-9de6-46b3-a86f-1047fc9278e9',
@@ -80,9 +75,6 @@ describe('PostService', () => {
   it('should return an array with 1 saved post', async () => {
     jest.spyOn(prisma.post, 'findMany').mockResolvedValue([mockTestPostSaved]);
     jest.spyOn(prisma.user, 'findUnique').mockResolvedValue(mockTestUser);
-    jest
-      .spyOn(presignedService, 'getDownloadURL')
-      .mockResolvedValue('https://example.com/presigned-url');
 
     const result = await service.getPostsWithSavedStatusPaginated(
       'b60b728d450146a1bbb4836ed61c93c7',
@@ -96,9 +88,6 @@ describe('PostService', () => {
   it('should return an array with 1 unsaved post', async () => {
     jest.spyOn(prisma.post, 'findMany').mockResolvedValue([mockTestPost]);
     jest.spyOn(prisma.user, 'findUnique').mockResolvedValue(mockTestUser);
-    jest
-      .spyOn(presignedService, 'getDownloadURL')
-      .mockResolvedValue('https://example.com/presigned-url');
 
     const result = await service.getPostsWithSavedStatusPaginated(
       '2140b95c-9de6-46b3-a86f-1047fc9278e9',

--- a/src/services/tests/statistics.service.spec.ts
+++ b/src/services/tests/statistics.service.spec.ts
@@ -51,7 +51,7 @@ describe('StatisticsService', () => {
     await expect(
       statisticsService.getUserStatistics('nonexistent-id'),
     ).rejects.toThrowError(
-      new HttpException('User not found', HttpStatus.NOT_FOUND),
+      new HttpException('User not found.', HttpStatus.NOT_FOUND),
     );
   });
 

--- a/src/services/tests/statistics.service.spec.ts
+++ b/src/services/tests/statistics.service.spec.ts
@@ -21,6 +21,16 @@ const mockPrismaService = {
 describe('StatisticsService', () => {
   let statisticsService: StatisticsService;
 
+  const fixedDate = new Date('2025-05-15T12:00:00Z');
+
+  beforeAll(() => {
+    jest.useFakeTimers().setSystemTime(fixedDate);
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -50,12 +60,15 @@ describe('StatisticsService', () => {
 
     mockPrismaService.userExercise.findMany.mockResolvedValue([
       {
+        createdAt: new Date('2025-05-01T12:00:00Z'),
         exercise: { interest: { title: 'Criatividade' } },
       },
       {
+        createdAt: new Date('2025-05-02T12:00:00Z'),
         exercise: { interest: { title: 'Comunicacao' } },
       },
       {
+        createdAt: new Date('2025-05-03T12:00:00Z'),
         exercise: { interest: { title: 'Criatividade' } },
       },
     ]);

--- a/src/services/tests/user.service.spec.ts
+++ b/src/services/tests/user.service.spec.ts
@@ -172,7 +172,7 @@ describe('UserService', () => {
       expect(result).toEqual(mockTestUserProfile);
     });
 
-    it('should throw exception if user not found', async () => {
+    it('should throw exception if user not found.', async () => {
       jest.spyOn(prisma.user, 'findUnique').mockResolvedValue(null);
 
       await expect(

--- a/src/services/tests/user.service.spec.ts
+++ b/src/services/tests/user.service.spec.ts
@@ -219,7 +219,7 @@ describe('UserService', () => {
 
       expect(updateSpy).toHaveBeenCalledTimes(1);
 
-      const calledArgs = updateSpy.mock.calls[0][0]; // pega os argumentos da chamada
+      const calledArgs = updateSpy.mock.calls[0][0];
       expect(calledArgs).toMatchObject({
         where: { user_id: user.user_id },
         data: { streak: 2 },

--- a/src/services/tests/user.service.spec.ts
+++ b/src/services/tests/user.service.spec.ts
@@ -167,9 +167,6 @@ describe('UserService', () => {
       jest
         .spyOn(prisma.post, 'findMany')
         .mockResolvedValue([mockTestPost, mockTestPostSaved]);
-      jest
-        .spyOn(presignedService, 'getDownloadURL')
-        .mockResolvedValue('https://example.com/presigned-url');
 
       const result = await service.getUserProfile(mockTestUser.user_id);
 

--- a/src/services/tests/user.service.spec.ts
+++ b/src/services/tests/user.service.spec.ts
@@ -24,7 +24,6 @@ jest.mock('@aws-sdk/client-s3');
 describe('UserService', () => {
   let service: UserService;
   let prisma: PrismaService;
-  let presignedService: PresignedService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -54,7 +53,6 @@ describe('UserService', () => {
 
     service = module.get<UserService>(UserService);
     prisma = module.get<PrismaService>(PrismaService);
-    presignedService = module.get<PresignedService>(PresignedService);
   });
 
   describe('create', () => {

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -253,6 +253,7 @@ export class UserService {
 
 function diffDays(d1: Date, d2: Date): number {
   const diff = d1.getTime() - d2.getTime();
+  // eslint-disable-next-line no-magic-numbers
   return Math.floor(diff / (1000 * 60 * 60 * 24));
 }
 

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -193,10 +193,12 @@ export class UserService {
       orderBy: { createdAt: 'desc' },
     });
 
+    const today = new Date();
     let newStreak: number;
     let daysSince: number;
+
     if (latestExercise && latestExercise.createdAt) {
-      daysSince = new Date().getDate() - latestExercise.createdAt.getDate();
+      daysSince = diffDays(today, latestExercise.createdAt);
     } else {
       const defaultDaysSince = 2;
       daysSince = defaultDaysSince;
@@ -205,14 +207,10 @@ export class UserService {
     if (latestExercise) {
       if (daysSince > 1) {
         newStreak = 0;
-      } else if (daysSince < 1) {
-        if (latestExercise.createdAt.getDate() !== user.updatedAt.getDate()) {
-          newStreak = user.streak + 1;
-        } else {
-          newStreak = user.streak;
-        }
       } else {
-        if (latestExercise.createdAt.getDate() !== user.updatedAt.getDate()) {
+        const alreadyUpdatedToday = isSameDay(user.updatedAt, today);
+
+        if (!alreadyUpdatedToday && (daysSince === 0 || daysSince === 1)) {
           newStreak = user.streak + 1;
         } else {
           newStreak = user.streak;
@@ -221,6 +219,7 @@ export class UserService {
     } else {
       newStreak = 0;
     }
+
     if (newStreak !== user.streak) {
       const data = UserMapper.toPrismaUpdateStreak(newStreak);
       await this.prisma.user.update({
@@ -250,4 +249,17 @@ export class UserService {
       lastExerciseDate: latestExercise?.createdAt || null,
     };
   }
+}
+
+function diffDays(d1: Date, d2: Date): number {
+  const diff = d1.getTime() - d2.getTime();
+  return Math.floor(diff / (1000 * 60 * 60 * 24));
+}
+
+function isSameDay(date1: Date, date2: Date): boolean {
+  return (
+    date1.getFullYear() === date2.getFullYear() &&
+    date1.getMonth() === date2.getMonth() &&
+    date1.getDate() === date2.getDate()
+  );
 }

--- a/test/fixture/library.mock.ts
+++ b/test/fixture/library.mock.ts
@@ -1,5 +1,5 @@
 import { Library, UserSavedLibrary } from '@prisma/client';
-import { LibraryResponseDTO } from '../../src/dtos/libraryDTO.dto';
+import { LibraryResponseDTO } from '../../src/dtos/library.dto';
 
 export function mockLibrary({
   library_id,

--- a/test/fixture/post.mock.ts
+++ b/test/fixture/post.mock.ts
@@ -57,11 +57,11 @@ export function mockPostResponse({
     post_id: post_id || 'd7e3b6e3-1f11-4fd2-86e3-23456789abcd',
     owner: owner || {
       name: 'John Doe',
-      profile_picture_url: 'https://thispersondoesnotexist.com/',
+      profile_picture_url: 'https://signedDownloadUrl.com',
     },
     title: title || 'Título do post',
     description: description || 'Descrição do post de exemplo',
-    image_url: image_url || 'https://img.com/post.png',
+    image_url: image_url || 'https://signedDownloadUrl.com',
     createdAt: createdAt || new Date('2025-04-01T12:00:00Z'),
     updatedAt: updatedAt || new Date('2025-04-01T12:00:00Z'),
     isSaved: isSaved ?? false,

--- a/test/fixture/user.mock.ts
+++ b/test/fixture/user.mock.ts
@@ -17,7 +17,7 @@ export function mockUser({
     email: email || 'John.doe@domain.com',
     description: description || 'This is a description',
     password: 'Senh@123',
-    profile_picture_path: 'https://thispersondoesnotexist.com/',
+    profile_picture_path: 'https://signedDownloadUrl.com',
     streak: streak || 0,
     createdAt: createdAt || new Date('2025-02-24T17:30:00'),
     updatedAt: updatedAt || new Date('2025-02-24T17:30:00'),

--- a/test/fixture/userExercise.mock.ts
+++ b/test/fixture/userExercise.mock.ts
@@ -1,0 +1,19 @@
+import { UserExercise } from '@prisma/client';
+
+export function mockUserExercise({
+  user_id,
+  exercise_id,
+  createdAt,
+  updatedAt,
+  deletedAt,
+}: Partial<UserExercise>): UserExercise {
+  return {
+    user_id: user_id || 'test-user-id',
+    exercise_id: exercise_id || 'test-exercise-id',
+    createdAt: createdAt || new Date('2025-06-01T10:00:00Z'),
+    updatedAt: updatedAt || new Date('2025-06-01T10:00:00Z'),
+    deletedAt: deletedAt || null,
+  };
+}
+
+export const mockTestUserExercise: UserExercise = mockUserExercise({});

--- a/test/fixture/userProfile.mock.ts
+++ b/test/fixture/userProfile.mock.ts
@@ -11,7 +11,7 @@ export function mockUserProfile({
     name: name || 'John Doe',
     description: description || 'This is a description',
     streak: streak || 0,
-    profilePictureUrl: profilePictureUrl || 'https://example.com/presigned-url',
+    profilePictureUrl: profilePictureUrl || 'https://signedDownloadUrl.com',
     posts: [mockTestPostResponse, mockTestPostResponseSaved],
   };
 }


### PR DESCRIPTION
**Descrição**

Arruma os testes do comando `npm run test`, e adiciona os testes para `getUserStreak` e `updateUserStreak`, de `user.service.ts`, que não haviam sido feitos ainda. 

Fazendo isso, também notei um problema com a lógica desses métodos, o que corrigi para fazer os testes ficarem corretos. (A comparação de datas estava usando apenas `getDate()`, mas esse método pega apenas o número do dia. (então, por exemplo, se você comparasse as datas 29 de abril e 30 de setembro, o código diria que tem 1 dia de diferença, e registraria a _streak_).